### PR TITLE
レイヤー削除後に他レイヤーの詳細画面が表示されないバグを修正

### DIFF
--- a/frontend/src/routes/map/components/layer_menu/LayerMenu.svelte
+++ b/frontend/src/routes/map/components/layer_menu/LayerMenu.svelte
@@ -190,7 +190,8 @@
 								index={i}
 								length={pointEntries.length}
 								layerType={'point'}
-								bind:layerEntry={pointEntries[i]}
+								{layerEntry}
+								bind:layerEntries
 								bind:showDataEntry
 								bind:tempLayerEntries
 								bind:enableFlip
@@ -213,7 +214,8 @@
 								index={i}
 								length={lineEntries.length}
 								layerType={'line'}
-								bind:layerEntry={lineEntries[i]}
+								{layerEntry}
+								bind:layerEntries
 								bind:showDataEntry
 								bind:tempLayerEntries
 								bind:enableFlip
@@ -236,7 +238,8 @@
 								index={i}
 								length={polygonEntries.length}
 								layerType={'polygon'}
-								bind:layerEntry={polygonEntries[i]}
+								{layerEntry}
+								bind:layerEntries
 								bind:showDataEntry
 								bind:tempLayerEntries
 								bind:enableFlip
@@ -259,7 +262,8 @@
 								index={i}
 								length={rasterEntries.length}
 								layerType={'raster'}
-								bind:layerEntry={rasterEntries[i]}
+								{layerEntry}
+								bind:layerEntries
 								bind:showDataEntry
 								bind:tempLayerEntries
 								bind:enableFlip

--- a/frontend/src/routes/map/components/layer_menu/LayerSlot.svelte
+++ b/frontend/src/routes/map/components/layer_menu/LayerSlot.svelte
@@ -20,6 +20,7 @@
 		length: number;
 		layerType: LayerType;
 		layerEntry: GeoDataEntry;
+		layerEntries: GeoDataEntry[];
 		showDataEntry: GeoDataEntry | null; // データメニューの表示状態
 		tempLayerEntries: GeoDataEntry[];
 		enableFlip: boolean;
@@ -30,7 +31,8 @@
 		index,
 		length,
 		layerType,
-		layerEntry = $bindable(),
+		layerEntry,
+		layerEntries = $bindable(),
 		showDataEntry = $bindable(), // データメニューの表示状態
 		tempLayerEntries = $bindable(),
 		enableFlip = $bindable(),
@@ -46,16 +48,18 @@
 	let isLayerInRange = $state(false);
 
 	let LayerBbox = $derived.by(() => {
-		return layerEntry.metaData.bounds;
+		return layerEntry?.metaData.bounds;
 	});
 
 	const selectedLayer = () => {
+		if (!layerEntry) return;
 		selectedLayerId.set(layerEntry.id);
 
 		if (!isLayerInRange && $isStyleEdit) mapStore.focusLayer(layerEntry);
 	};
 
 	isStyleEdit.subscribe((value) => {
+		if (!layerEntry) return;
 		if (value && $selectedLayerId === layerEntry.id && !isLayerInRange) {
 			mapStore.focusLayer(layerEntry);
 		}


### PR DESCRIPTION
## 概要
  レイヤーを削除した後、他のレイヤーの詳細画面（スタ
  イル編集画面）を開こうとすると、何も表示されなくな
  るバグを修正しました。

  ## 問題の原因
  LayerMenu.svelteで各レイヤーコンポーネントに対して
  `bind:layerEntry={pointEntries[i]}`のように**配列
  のインデックス**でバインディングしていたことが原因
  でした。

  ```svelte
  <!-- 修正前 -->
  {#each pointEntries as layerEntry, i
  (layerEntry.id)}
    <LayerSlot bind:layerEntry={pointEntries[i]} />
  {/each}
  ```
  この実装では以下の問題が発生していました：
  1. レイヤー削除時に配列が再構築される
  2. インデックスがずれるが、Svelteは(layerEntry.id)
  をキーにDOMを再利用
  3. 結果として、削除されたエントリーや間違ったエン
  トリーを参照してしまう

  解決方法

  {#each}ループのスコープ変数を直接プロップスとして
  渡すように変更しました。

  ```svelte
  <!-- 修正後 -->
  {#each pointEntries as layerEntry, i
  (layerEntry.id)}
    <LayerSlot {layerEntry} />
  {/each}
 ```

  これにより、配列の再構築に関わらず、常に正しいレイ
  ヤーエントリーが参照されるようになります。

  変更内容

  - LayerMenu.svelte: インデックスベースのバインディ
  ングを削除し、ループ変数を直接渡すように変更
  - LayerSlot.svelte:
  layerEntryを直接プロップスとして受け取るように変更

  テスト内容

  - レイヤーを削除後、他のレイヤーの詳細画面が正常に
  表示されることを確認
  - レイヤーの表示/非表示切り替えが正常に動作するこ
  とを確認
  - レイヤーの並び替えが正常に動作することを確認